### PR TITLE
feat(preconditions): add ETag/If-Match middleware with tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ '**' ]
+    branches: ["**"]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -22,47 +22,82 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-       
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
-       
-      - name: Install dependencies
+
+      - name: Install deps
         run: npm ci
-       
-      - name: Run unit tests (Vitest)
-        run: npm test
+
+      - name: Run API/Unit tests (Vitest)
+        run: npm run test:api
+
+      # Optional: upload vitest artifacts on failure (if you generate any)
+      - name: Upload unit test results (if any)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-results
+          path: |
+            test-results/**
+            **/junit*.xml
+          if-no-files-found: ignore
 
   test-e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
     needs: test-unit
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-       
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
-       
-      - name: Install dependencies
+
+      # Cache Playwright browser binaries to speed up CI
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install deps
         run: npm ci
-       
-      - name: Install Playwright
+
+      # Install Playwright browsers and Linux system deps
+      - name: Install Playwright browsers
         run: npx playwright install --with-deps
-       
-      - name: Run Playwright tests
-        run: npx playwright test -c playwright.config.ts
-       
-      - name: Upload Playwright report (on failure)
+
+      # Run E2E tests; playwright.config.ts starts the API via `npm run dev:api` on PORT=4000
+      - name: Run E2E tests (Playwright)
+        env:
+          HOST: 0.0.0.0
+          PORT: 4000
+          NODE_ENV: test
+        run: npm run test:e2e
+
+      # Upload Playwright reports on failure for debugging
+      - name: Upload Playwright report
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report
           path: playwright-report
+          if-no-files-found: ignore
+
+      - name: Upload Playwright blob report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-blob-report
+          path: blob-report
           if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ node_modules
 dist
 .env
 .vscode
+
+# Test reports
+playwright-report/
+blob-report/
+test-results/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Notes
 - Playwright runs API at `PORT=4000` via `npm run dev:api` and waits on `/health`.
 - Vitest excludes e2e tests via `vitest.config.ts` to avoid runner conflicts.
+## [Unreleased]
+- feat: ETag/If-Match preconditions with 428/412 handling (unit + e2e)
+

--- a/README.md
+++ b/README.md
@@ -82,3 +82,45 @@ Add middleware + tests for ETag / If-Match preconditions (HTTP 412/428).
 Extend CI with those new tests.
 
 Use this template as a baseline for coding tasks and project scaffolding.
+
+## Candidate Task — Preconditions & Concurrency
+
+### Objective
+Implement optimistic concurrency on a demo resource using HTTP preconditions and ETags, with unit and E2E tests enforced by CI.
+
+### Starting Point
+- Express app with `/health`, `/item` demo, and robust ETag middleware.
+- Unit tests (Vitest + Supertest) and E2E tests (Playwright) scaffolded.
+- CI + branch protection require green checks.
+
+### Requirements
+1. Extend `/item` to support:
+   - `If-None-Match` on `GET /item` → return `304` when tag matches.
+   - `DELETE /item` that requires `If-Match` (428/412 rules apply).
+2. Add **at least 2** new unit tests and **1** E2E test covering these flows.
+3. All tests must pass locally and in CI.
+
+### Constraints
+- Strong ETags (quoted) for matching; treat weak tags as equivalent when provided.
+- No DB needed (in-memory OK), but structure code so an async tag supplier would work.
+
+### Acceptance Criteria
+- `GET /item` returns `304` when `If-None-Match` equals current ETag.
+- `DELETE /item` returns:
+  - 428 when `If-Match` missing
+  - 412 when tag stale
+  - 200 when tag matches (and bumps version or recreates item on next GET)
+- Tests: passing locally (`npm run test:all`) and in PR CI.
+
+### How to run
+```bash
+npm run test:api
+npm run test:e2e
+Evaluation Rubric
+Correct HTTP semantics (428/412/304/200): 40%
+
+Test quality and coverage: 30%
+
+Code clarity and extensibility (async-ready, clean middleware): 20%
+
+Git hygiene (small commits, clear messages): 10%

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,10 @@
         "@playwright/test": "^1.55.0",
         "@types/express": "^4.17.21",
         "@types/node": "^20.12.12",
-        "@types/supertest": "^6.0.2",
+        "@types/supertest": "^6.0.3",
         "cross-env": "^7.0.3",
-        "supertest": "^7.0.0",
-        "tsx": "^4.16.0",
+        "supertest": "^7.1.4",
+        "tsx": "^4.20.5",
         "typescript": "^5.5.4",
         "vitest": "^1.6.0"
       }

--- a/package.json
+++ b/package.json
@@ -6,9 +6,19 @@
   "scripts": {
     "start:api": "tsx server/index.ts",
     "dev:api": "cross-env PORT=4000 tsx server/index.ts",
+
+    "// --- Unit/API tests (Vitest)": "",
     "test": "vitest run -c vitest.config.ts",
     "test:watch": "vitest -c vitest.config.ts",
-    "test:e2e": "playwright test -c playwright.config.ts"
+    "test:api": "vitest run -c vitest.config.ts --dir tests/api",
+
+
+
+    "// --- End-to-end tests (Playwright)": "",
+    "test:e2e": "playwright test -c playwright.config.ts",
+
+    "// --- Convenience combo": "",
+    "test:all": "npm run test:api && npm run test:e2e"
   },
   "dependencies": {
     "express": "^4.19.2"
@@ -17,10 +27,10 @@
     "@playwright/test": "^1.55.0",
     "@types/express": "^4.17.21",
     "@types/node": "^20.12.12",
-    "@types/supertest": "^6.0.2",
+    "@types/supertest": "^6.0.3",
     "cross-env": "^7.0.3",
-    "supertest": "^7.0.0",
-    "tsx": "^4.16.0",
+    "supertest": "^7.1.4",
+    "tsx": "^4.20.5",
     "typescript": "^5.5.4",
     "vitest": "^1.6.0"
   }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,21 +1,27 @@
-import { defineConfig } from '@playwright/test';
+import { defineConfig } from "@playwright/test";
+
+// Keep HOST/PORT in one place and reuse for baseURL + webServer
+const HOST = process.env.HOST ?? "127.0.0.1"; // Playwright reaches this host
+const PORT = Number(process.env.PORT ?? 4000);
+const BASE_URL = process.env.PW_BASE_URL ?? `http://${HOST}:${PORT}`;
 
 export default defineConfig({
-  // Only discover tests in this folder…
-  testDir: 'tests/e2e',
-  // …and only these files are tests
-  testMatch: /.*\.e2e\.spec\.ts$/,
-
+  testDir: "tests/e2e",
   timeout: 30_000,
+  retries: process.env.CI ? 2 : 0,
   use: {
-    baseURL: 'http://localhost:4000',
+    baseURL: BASE_URL,
   },
-
-  // Start the API that tests hit
+  reporter: process.env.CI ? [["github"], ["list"]] : [["list"]],
   webServer: {
-    command: 'npm run dev:api',                 // this sets PORT=4000
-    url: 'http://localhost:4000/health',        // wait for health
+    // Start the API for E2E; use env so this works cross-platform (Windows-safe)
+    command: "npm run dev:api",
+    url: `${BASE_URL}/health`,
     reuseExistingServer: !process.env.CI,
-    timeout: 60_000
+    timeout: 120_000,
+    env: {
+      HOST,              // passed to server/index.ts
+      PORT: String(PORT) // passed to server/index.ts
+    }
   }
 });

--- a/protection.json
+++ b/protection.json
@@ -1,0 +1,12 @@
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["Unit Tests", "E2E Tests"]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 0,
+    "dismiss_stale_reviews": false
+  },
+  "restrictions": null
+}

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,8 +1,75 @@
-import express from "express";
+import express, { type Request, type Response, type NextFunction } from "express";
 
 export const app = express();
 app.use(express.json());
 
-app.get("/health", (_req, res) => {
+// Request log (helps see if /health is reached)
+app.use((req, _res, next) => {
+  console.log(`[req] ${req.method} ${req.url}`);
+  next();
+});
+
+// --- Health endpoint (what Playwright waits on) ---
+app.get("/health", (_req: Request, res: Response) => {
   res.status(200).json({ ok: true });
+});
+
+// --- Demo item routes (optional; your tests use these) ---
+type Item = { id: string; value: string; version: number };
+let item: Item = { id: "item-1", value: "hello", version: 1 };
+export function __resetDemoItem() {
+  item = { id: "item-1", value: "hello", version: 1 };
+}
+const etagFromVersion = (v: number) => `"${v}"`;
+const currentTag = () => etagFromVersion(item.version);
+
+function normalizeStrongETag(tag: string): string {
+  const t = tag.trim().replace(/^W\//, "");
+  return /^".*"$/.test(t) ? t : `"${t.replace(/^"+|"+$/g, "")}"`;
+}
+function parseIfMatchHeader(h?: string | null): { star: boolean; tags: string[] } {
+  if (!h) return { star: false, tags: [] };
+  const raw = h.trim();
+  if (raw === "*") return { star: true, tags: [] };
+  return { star: false, tags: raw.split(",").map(s => normalizeStrongETag(s)) };
+}
+
+app.get("/item", (_req, res) => {
+  res.set("ETag", currentTag());
+  res.json({ id: item.id, value: item.value, version: item.version });
+});
+
+app.put("/item", (req, res, next) => {
+  const parsed = parseIfMatchHeader(req.header("if-match"));
+  if (!req.header("if-match") || (!parsed.star && parsed.tags.length === 0)) {
+    return res.status(428).json({ error: "precondition_required", message: "If-Match header is required for this operation" });
+  }
+  (res.locals as any).ifMatch = parsed;
+  next();
+}, (req, res, next) => {
+  const provided = (res.locals as any).ifMatch as ReturnType<typeof parseIfMatchHeader>;
+  if (provided.star) return next();
+  const expected = normalizeStrongETag(currentTag());
+  const ok = provided.tags.some(t => normalizeStrongETag(t) === expected);
+  if (!ok) {
+    return res.status(412).json({ error: "precondition_failed", message: "If-Match does not match the current representation" });
+  }
+  next();
+}, (req, res) => {
+  if (typeof req.body?.value === "string") item.value = req.body.value;
+  item.version += 1;
+  res.set("ETag", currentTag());
+  res.status(200).json({ ok: true, version: item.version });
+});
+
+// 404 handler so curl doesn’t see an empty socket close
+app.use((req, res) => {
+  res.status(404).json({ error: "not_found", path: req.url });
+});
+
+// Central error handler to avoid empty replies on exceptions
+app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
+  console.error("[error]", err);
+  if (res.headersSent) return;
+  res.status(500).json({ error: "internal_error" });
 });

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,7 +1,13 @@
-import { app } from "./app.js";
+import { app } from "./app.ts";
 
-const port = Number(process.env.PORT ?? 4000);
+const host = process.env.HOST ?? "0.0.0.0";
+const port = Number(process.env.PORT ?? 3000);
 
-app.listen(port, () => {
-  console.log(`[pathfinder] API listening on http://localhost:${port}`);
+const server = app.listen(port, host, () => {
+  console.log(`[server] listening on http://${host}:${port}`);
 });
+
+process.on("SIGTERM", () => server.close());
+process.on("SIGINT", () => server.close());
+
+export default server;

--- a/server/middleware/preconditions.ts
+++ b/server/middleware/preconditions.ts
@@ -1,0 +1,59 @@
+import type { Request, Response, NextFunction } from "express";
+
+const isWeak = (t: string) => t.startsWith('W/"');
+const stripWeak = (t: string) => (isWeak(t) ? t.slice(2) : t);
+const isQuoted = (t: string) => /^".*"$/.test(t);
+const quote = (s: string) => (isQuoted(s) ? s : `"${s}"`);
+
+export function normalizeStrongETag(tag: string): string {
+  const noWeak = stripWeak(tag.trim());
+  return quote(noWeak.replace(/^"+|"+$/g, ""));
+}
+
+export function parseIfMatchHeader(h?: string | null): { star: boolean; tags: string[] } {
+  if (!h) return { star: false, tags: [] };
+  const raw = h.trim();
+  if (raw === "*") return { star: true, tags: [] };
+  const parts = raw.split(",").map((s) => s.trim()).filter(Boolean);
+  return { star: false, tags: parts.map(normalizeStrongETag) };
+}
+
+export function setETag(res: Response, tag: string) {
+  res.set("ETag", normalizeStrongETag(tag));
+}
+
+export function requireIfMatch(req: Request, res: Response, next: NextFunction) {
+  const h = req.header("if-match");
+  const parsed = parseIfMatchHeader(h);
+  if (!h || (!parsed.star && parsed.tags.length === 0)) {
+    return res.status(428).json({
+      error: "precondition_required",
+      message: "If-Match header is required for this operation",
+    });
+  }
+  res.locals.ifMatch = parsed;
+  next();
+}
+
+export function preconditionMatches(
+  currentTag: string | (() => string | Promise<string>)
+) {
+  return async (_req: Request, res: Response, next: NextFunction) => {
+    const provided = res.locals.ifMatch as ReturnType<typeof parseIfMatchHeader>;
+    if (provided?.star) return next();
+    const expectedRaw = typeof currentTag === "function" ? await currentTag() : currentTag;
+    const expected = normalizeStrongETag(expectedRaw);
+    const ok = provided.tags.some((t) => normalizeStrongETag(t) === expected);
+    if (!ok) {
+      return res.status(412).json({
+        error: "precondition_failed",
+        message: "If-Match does not match the current representation",
+      });
+    }
+    next();
+  };
+}
+
+export function etagFromVersion(v: number): string {
+  return `"${v}"`;
+}

--- a/tests/api/preconditions.spec.ts
+++ b/tests/api/preconditions.spec.ts
@@ -1,0 +1,81 @@
+import request from "supertest";
+import { describe, it, expect, beforeEach } from "vitest";
+import { app, __resetDemoItem } from "../../server/app.js";
+
+describe("ETag / If-Match preconditions", () => {
+  beforeEach(() => {
+    __resetDemoItem();
+  });
+
+  it("GET /item returns strong ETag", async () => {
+    const res = await request(app).get("/item");
+    expect(res.status).toBe(200);
+    expect(res.headers).toHaveProperty("etag");
+    const etag = res.headers["etag"];
+    expect(/^".+"$/.test(etag)).toBe(true);
+  });
+
+  it("PUT /item without If-Match → 428", async () => {
+    const res = await request(app).put("/item").send({ value: "x" });
+    expect(res.status).toBe(428);
+  });
+
+  it("PUT /item with wrong If-Match → 412", async () => {
+    const res = await request(app)
+      .put("/item")
+      .set("If-Match", '"bogus"')
+      .send({ value: "x" });
+    expect(res.status).toBe(412);
+  });
+
+  it('PUT /item with If-Match: * succeeds', async () => {
+    const res = await request(app)
+      .put("/item")
+      .set("If-Match", "*")
+      .send({ value: "wildcard" });
+    expect(res.status).toBe(200);
+  });
+
+  it("PUT /item with list matches any", async () => {
+    const g1 = await request(app).get("/item");
+    const etag1 = g1.headers["etag"] as string;
+
+    const res = await request(app)
+      .put("/item")
+      .set("If-Match", `"nope", ${etag1}`)
+      .send({ value: "ok" });
+    expect(res.status).toBe(200);
+  });
+
+  it("PUT /item with weak tag equivalent succeeds", async () => {
+    const g = await request(app).get("/item");
+    const strong = g.headers["etag"] as string;
+    const weak = `W/${strong}`;
+    const res = await request(app)
+      .put("/item")
+      .set("If-Match", weak)
+      .send({ value: "updated" });
+    expect(res.status).toBe(200);
+  });
+
+  it("ETag changes after successful update; stale tag fails later", async () => {
+    const g1 = await request(app).get("/item");
+    const etag1 = g1.headers["etag"] as string;
+
+    const ok = await request(app)
+      .put("/item")
+      .set("If-Match", etag1)
+      .send({ value: "updated" });
+    expect(ok.status).toBe(200);
+
+    const g2 = await request(app).get("/item");
+    const etag2 = g2.headers["etag"] as string;
+    expect(etag2).not.toBe(etag1);
+
+    const stale = await request(app)
+      .put("/item")
+      .set("If-Match", etag1)
+      .send({ value: "again" });
+    expect(stale.status).toBe(412);
+  });
+});

--- a/tests/e2e/preconditions.e2e.spec.ts
+++ b/tests/e2e/preconditions.e2e.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from "@playwright/test";
+
+test("ETag / If-Match flow", async ({ request, baseURL }) => {
+  const r1 = await request.get(`${baseURL}/item`);
+  expect(r1.status()).toBe(200);
+  const etag1 = r1.headers()["etag"];
+  expect(etag1).toBeTruthy();
+
+  const r428 = await request.put(`${baseURL}/item`, { data: { value: "x" } });
+  expect(r428.status()).toBe(428);
+
+  const r412 = await request.put(`${baseURL}/item`, {
+    headers: { "If-Match": '"nope"' },
+    data: { value: "x" },
+  });
+  expect(r412.status()).toBe(412);
+
+  // wildcard
+  const okWildcard = await request.put(`${baseURL}/item`, {
+    headers: { "If-Match": "*" },
+    data: { value: "wild" },
+  });
+  expect(okWildcard.status()).toBe(200);
+
+  // weak tag equivalent
+  const r2 = await request.get(`${baseURL}/item`);
+  const etag2 = r2.headers()["etag"]!;
+  const weak = `W/${etag2}`;
+  const okWeak = await request.put(`${baseURL}/item`, {
+    headers: { "If-Match": weak },
+    data: { value: "weak-ok" },
+  });
+  expect(okWeak.status()).toBe(200);
+
+  // list
+  const r3 = await request.get(`${baseURL}/item`);
+  const etag3 = r3.headers()["etag"]!;
+  const okList = await request.put(`${baseURL}/item`, {
+    headers: { "If-Match": `"nope", ${etag3}` },
+    data: { value: "list-ok" },
+  });
+  expect(okList.status()).toBe(200);
+
+  // tag changes each update
+  const r4 = await request.get(`${baseURL}/item`);
+  const etag4 = r4.headers()["etag"]!;
+  expect(etag4).not.toBe(etag2);
+});


### PR DESCRIPTION
### Summary
- Added robust ETag/If-Match middleware with 428/412 handling
- Demo resource `/item` with versioned ETags
- Unit tests (Vitest + Supertest)
- E2E tests (Playwright) covering flows
- Updated CI workflow with Unit + E2E jobs and Playwright cache

### Notes
- Branch protection enforces Unit + E2E checks
- Ready for candidate tasks or extension with If-None-Match/DELETE flows